### PR TITLE
Add support for non-local resources

### DIFF
--- a/easy_pdf/rendering.py
+++ b/easy_pdf/rendering.py
@@ -24,8 +24,6 @@ def fetch_resources(uri, rel):
     """
     Retrieves embeddable resource from given ``uri``.
 
-    For now only local resources (images, fonts) are supported.
-
     :param str uri: path or url to image or font resource
     :returns: path to local resource file.
     :rtype: str


### PR DESCRIPTION
Now supports HTML URIs with relative protocol (starts with `//example.com/image.png`), http:// and https://. This PR would resolve #7.
