### PR TITLE
doc: update py3 requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,10 @@ Quickstart
 ----------
 
 1. Include ``django-easy-pdf``, ``xhtml2pdf>=0.0.6`` and ``reportlab>=2.7,<3``
-   in your ``requirements.txt`` file.
+   in your ``requirements.txt`` file. If you are on Python 3 you need to install
+   the latest version of Reportlab and the beta version of xhtml2pdf::
+
+    $ pip install --pre xhtml2pdf
 
 2. Add ``easy_pdf`` to ``INSTALLED_APPS``.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,3 +7,8 @@ to your ``requirements.txt`` file or install it directly from the command line b
 
     $ pip install django-easy-pdf
     $ pip install "xhtml2pdf>=0.0.6" "reportlab>=2.7,<3"
+
+If you are on Python 3 you need to install the latest version of Reportlab
+and the beta version of xhtml2pdf::
+
+    $ pip install --pre xhtml2pdf


### PR DESCRIPTION
Hi, I noticed that the docs can be updated slightly to instruct people on how to successfully use django-easy-pdf on Python 3 now that [xhtml2pdf py3k is in beta](https://github.com/xhtml2pdf/xhtml2pdf#xhtml2pdf). And people [are trying](http://stackoverflow.com/a/21312892/544059)… :)