### PR TITLE
Port base template to jinja2

### DIFF
--- a/easy_pdf/jinja2/easy_pdf/base.html
+++ b/easy_pdf/jinja2/easy_pdf/base.html
@@ -1,0 +1,60 @@
+{# jinja port of built-in django template #}
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ title or "" }}</title>
+
+    {% block style_base %}
+        {#
+            See DEFAULT_CSS in https://github.com/chrisglass/xhtml2pdf/blob/master/xhtml2pdf/default.py
+            for base style.
+        #}
+
+        {% block layout_style %}
+            <style type="text/css">
+                @page {
+                    size: {{ pagesize or "A4" }};
+                    margin-left: 2.5cm;
+                    margin-right: 2.5cm;
+                    margin-top: 2.5cm;
+                    margin-bottom: 2cm;
+
+                    @frame header {
+                        -pdf-frame-content: page-header;
+                        margin-top: 0.7cm;
+                        margin-right: 2mm;
+                        margin-bottom: 0cm;
+                        margin-left: 1.2cm;
+                    }
+
+                    @frame footer {
+                        -pdf-frame-content: page-footer;
+                        bottom: 0cm;
+                        margin-left: 1cm;
+                        margin-right: 1cm;
+                        height: 1cm;
+                    }
+                }
+            </style>
+        {%endblock%}
+        {% block extra_style %}{% endblock %}
+    {% endblock %}
+</head>
+<body>
+    <div>
+        {%block page_header%}
+        {%endblock%}
+
+        {%block content%}
+        {%endblock%}
+    </div>
+
+    <div id="page-footer">
+        {%block page_foot%}
+            {#
+                <pdf:pagenumber />
+            #}
+        {%endblock%}
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Django looks in the jinja2 subdirectory, so this should work out of the box with the jinja2 template engine, if APP_DIRS is set to true in the template settings, i.e.

```
TEMPLATES = [
    {
        'BACKEND': 'django.template.backends.jinja2.Jinja2',
        'DIRS': ['[site template dir]'],
        'APP_DIRS': True,
    },
]
```