### PR TITLE
.dockerignore should not restrict access to docs/requirements.txt

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,7 +34,6 @@ docs/_build/
 nosetests.xml
 .env
 .idea
-/docs
 .dockerignore
 .gitattributes
 .gitignore


### PR DESCRIPTION
removing docs/ from dockerignore solve the fail in the docker build

`Step 12/17 : COPY /home/baptiste/Documents/django-easy-pdf/docs/requirements.txt /app/docs/
COPY failed: stat /var/lib/docker/tmp/docker-builderXXXXX`