### PR TITLE
Change wrong version in docs.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,7 +2,7 @@
 Installation
 ============
 
-1. Add ``django-easy-pdf==0.2.0`` and ``WeasyPrint>=0.34``
+1. Add ``django-easy-pdf==0.1.1`` and ``WeasyPrint>=0.34``
    to your ``requirements.txt`` file or install it directly from the command line by invoking::
 
         $ pip install -U django-easy-pdf WeasyPrint


### PR DESCRIPTION
We get an error if we use 0.2.0 . `Could not find a version that satisfies the requirement django-easy-pdf==0.2.0`. We can change this after the release of 0.2.0