### PR TITLE
Fixes #72: Add django 3 support

### DIFF
--- a/easy_pdf/compat.py
+++ b/easy_pdf/compat.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+
+import sys
+
+__all__ = ['BytesIO']
+
+PY2 = sys.version_info[0] == 2
+
+if PY2:
+    import StringIO
+    BytesIO = StringIO.StringIO
+else:
+    import io
+    BytesIO = io.BytesIO

--- a/easy_pdf/rendering.py
+++ b/easy_pdf/rendering.py
@@ -9,11 +9,11 @@ from django.conf import settings
 from django.template import loader
 from django.http import HttpResponse
 from django.utils.http import urlquote
-from django.utils.six import BytesIO
 
 import xhtml2pdf.default
 from xhtml2pdf import pisa
 
+from .compat import BytesIO
 from .exceptions import UnsupportedMediaPathException, PDFRenderingError
 
 logger = logging.getLogger("app.pdf")


### PR DESCRIPTION
Enable `easy_pdf` to be installed in Django 3.0 by dropping the dependency of `django.utils.six` module, which is [no longer present in Django 3.0](https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis).

Instead, the classes that need compatibility with Python 2 have been added to the new `compat` module.

Fixes #72 